### PR TITLE
Gameplay core issues joystick

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@
  * Root component that manages game state and renders appropriate screens
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { audioEngine } from "./Core/AudioEngine";
 import { inputSystem } from "./Core/InputSystem";
 import { Canteen } from "./Scenes/Canteen";
@@ -14,7 +14,8 @@ import { useGameStore } from "./stores/gameStore";
 import { HUD } from "./UI/HUD";
 
 export function App() {
-	const { mode, loadData } = useGameStore();
+	const { mode, loadData, hudReady } = useGameStore();
+	const inputInitialized = useRef(false);
 
 	// Initialize on mount
 	useEffect(() => {
@@ -26,9 +27,6 @@ export function App() {
 			await audioEngine.init();
 			audioEngine.playMusic("menu");
 		};
-
-		// Initialize input system
-		inputSystem.init();
 
 		// Setup audio initialization on first interaction
 		const handleInteraction = () => {
@@ -46,6 +44,19 @@ export function App() {
 			inputSystem.destroy();
 		};
 	}, [loadData]);
+
+	// Initialize input system when entering GAME mode and HUD is ready (deterministic)
+	useEffect(() => {
+		if (mode === "GAME" && hudReady && !inputInitialized.current) {
+			inputSystem.init();
+			inputInitialized.current = true;
+		}
+		// Destroy input system when exiting GAME mode
+		if (mode !== "GAME" && inputInitialized.current) {
+			inputSystem.destroy();
+			inputInitialized.current = false;
+		}
+	}, [mode, hudReady]);
 
 	useEffect(() => {
 		if (mode === "GAME") {

--- a/src/Core/InputSystem.ts
+++ b/src/Core/InputSystem.ts
@@ -261,32 +261,55 @@ export class InputSystem {
 	}
 
 	/**
-	 * Cleanup
+	 * Cleanup - safe to call even when not initialized
 	 */
 	destroy(): void {
+		// Destroy joysticks (optional chaining handles null case)
 		this.moveJoystick?.destroy();
+		this.moveJoystick = null;
 		this.lookJoystick?.destroy();
+		this.lookJoystick = null;
 
+		// Remove event listeners (guards ensure safety when not initialized)
 		if (this.handleDeviceOrientation) {
 			window.removeEventListener("deviceorientation", this.handleDeviceOrientation);
+			this.handleDeviceOrientation = null;
 		}
 		if (this.handleKeyDown) {
 			window.removeEventListener("keydown", this.handleKeyDown);
+			this.handleKeyDown = null;
 		}
 		if (this.handleKeyUp) {
 			window.removeEventListener("keyup", this.handleKeyUp);
+			this.handleKeyUp = null;
 		}
 		if (this.lookZone) {
 			if (this.handleTouchStart) {
 				this.lookZone.removeEventListener("touchstart", this.handleTouchStart);
+				this.handleTouchStart = null;
 			}
 			if (this.handleTouchMove) {
 				this.lookZone.removeEventListener("touchmove", this.handleTouchMove);
+				this.handleTouchMove = null;
 			}
 			if (this.handleTouchEnd) {
 				this.lookZone.removeEventListener("touchend", this.handleTouchEnd);
+				this.handleTouchEnd = null;
 			}
+			this.lookZone = null;
 		}
+
+		// Reset input state
+		this.state = {
+			move: { x: 0, y: 0, active: false },
+			look: { x: 0, y: 0, active: false },
+			drag: { x: 0, y: 0, active: false },
+			gyro: { x: 0, y: 0 },
+			zoom: false,
+			jump: false,
+			grip: false,
+		};
+		this.gyroEnabled = false;
 	}
 }
 

--- a/src/Scenes/GameWorld.tsx
+++ b/src/Scenes/GameWorld.tsx
@@ -107,7 +107,7 @@ export function GameWorld() {
 			<EffectComposer>
 				<Bloom intensity={0.5} />
 				<Noise opacity={0.05} />
-				<Vignette darkness={1.2} />
+				<Vignette darkness={0.4} offset={0.3} />
 				<BrightnessContrast brightness={0.05} contrast={0.2} />
 				<HueSaturation saturation={-0.2} />
 			</EffectComposer>

--- a/src/Scenes/GameWorld/components/GameLogic.tsx
+++ b/src/Scenes/GameWorld/components/GameLogic.tsx
@@ -186,13 +186,22 @@ export function GameLogic({
 			playerRef.current.position.z,
 		]);
 
+		// Over-the-shoulder camera: positioned BEHIND the player (-Z), looking forward
 		const targetDist = isZoomed ? 6 : 12;
-		const cameraOffset = new THREE.Vector3(1.5, 4, targetDist).applyAxisAngle(
+		// Look-ahead distance scales with camera distance (25% of targetDist)
+		const LOOK_AHEAD_RATIO = 0.25;
+		const lookAheadDist = targetDist * LOOK_AHEAD_RATIO;
+		const cameraOffset = new THREE.Vector3(1.5, 4, -targetDist).applyAxisAngle(
 			new THREE.Vector3(0, 1, 0),
 			playerRef.current.rotation.y,
 		);
 		state.camera.position.lerp(playerRef.current.position.clone().add(cameraOffset), 0.08);
-		state.camera.lookAt(playerRef.current.position.clone().add(new THREE.Vector3(0, 0.8, 0)));
+		// Look ahead of the player, not at the player
+		const lookTarget = new THREE.Vector3(0, 0.8, lookAheadDist).applyAxisAngle(
+			new THREE.Vector3(0, 1, 0),
+			playerRef.current.rotation.y,
+		);
+		state.camera.lookAt(playerRef.current.position.clone().add(lookTarget));
 	});
 
 	return null;

--- a/src/UI/HUD.tsx
+++ b/src/UI/HUD.tsx
@@ -41,6 +41,13 @@ export function HUD() {
 	const toggleZoom = useGameStore((state) => state.toggleZoom);
 	const setBuildMode = useGameStore((state) => state.setBuildMode);
 	const placeComponent = useGameStore((state) => state.placeComponent);
+	const setHudReady = useGameStore((state) => state.setHudReady);
+
+	// Signal HUD mount/unmount for input system initialization
+	useEffect(() => {
+		setHudReady(true);
+		return () => setHudReady(false);
+	}, [setHudReady]);
 
 	// Track damage flash for directional indicator
 	const [showDamageFlash, setShowDamageFlash] = useState(false);

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -144,6 +144,8 @@ interface GameState {
 	// UI state
 	isZoomed: boolean;
 	toggleZoom: () => void;
+	hudReady: boolean;
+	setHudReady: (ready: boolean) => void;
 }
 
 // Use CHUNK_SIZE from GAME_CONFIG for consistency
@@ -167,6 +169,7 @@ export const useGameStore = create<GameState>((set, get) => ({
 	isZoomed: false,
 	isBuildMode: false,
 	currentChunkId: "0,0",
+	hudReady: false,
 
 	// Mode management
 	setMode: (mode) => set({ mode }),
@@ -640,6 +643,7 @@ export const useGameStore = create<GameState>((set, get) => ({
 	},
 
 	toggleZoom: () => set((state) => ({ isZoomed: !state.isZoomed })),
+	setHudReady: (ready: boolean) => set({ hudReady: ready }),
 
 	collectSpoils: (type: "credit" | "clam") => {
 		set((state) => ({


### PR DESCRIPTION
Fixes missing left joystick and incorrect camera view.

The left joystick was not showing because `inputSystem.init()` was called before the HUD with joystick zones was rendered. The camera had an unwanted "gunsight" effect due to an excessively high `Vignette` darkness value.

---
<a href="https://cursor.com/background-agent?bcId=bc-7577bbaa-c8e8-43b9-a873-d7936b2e99e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7577bbaa-c8e8-43b9-a873-d7936b2e99e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes testing and CI while addressing input/camera issues.
> 
> - **Input & visuals**: Gate `inputSystem.init()` on `hudReady`, destroy on exit in `App.tsx`; adjust `Vignette` settings in `GameWorld` to remove gunsight effect
> - **E2E overhaul**: Replace monolithic test with modular specs (`gameplay.spec.ts`, `advanced-mechanics.spec.ts`, `canteen.spec.ts`, `character-selection.spec.ts`, `save-persistence.spec.ts`, `error-handling.spec.ts`, visual audits) plus shared `helpers.ts`
> - **CI/workflows**: Bump `coverallsapp/github-action` to v2.3.7, `actions/github-script` to v8, and all `anthropics/claude-code-action` uses to v1.0.27; add Playwright caching and artifact uploads
> - **Repo hygiene**: Add Playwright artifacts to `.gitignore`; add `REFACTORING_PLAN.md` and memory bank context/dev logs for ongoing refactor tracking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b0bb698dc4d8870604c624ab172672a6636143. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->