### PR TITLE
fix(e2e): Use force clicks for cutscene dialogue buttons

### DIFF
--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -204,19 +204,16 @@ test.describe("OTTER: ELITE FORCE - Game Flow", () => {
 		let buttonText = await nextBtn.innerText();
 		let clickCount = 0;
 		while (buttonText.includes("NEXT") && clickCount < 20) {
-			await nextBtn.click();
-			await page.waitForTimeout(500); // Brief pause between clicks
+			await nextBtn.click({ force: true });
+			await page.waitForTimeout(300); // Brief pause between clicks
 			buttonText = await nextBtn.innerText();
 			clickCount++;
 		}
 
-		// Final click on BEGIN MISSION - use JS click for animation stability
+		// Final click on BEGIN MISSION - use force:true for animation stability
 		const beginMissionBtn = page.locator('button.dialogue-next:has-text("BEGIN MISSION")');
 		await expect(beginMissionBtn).toBeVisible({ timeout: 5000 });
-		await page.evaluate(() => {
-			const btn = document.querySelector("button.dialogue-next") as HTMLButtonElement;
-			if (btn) btn.click();
-		});
+		await beginMissionBtn.click({ force: true });
 		await page.waitForTimeout(500);
 
 		// CRITICAL: Verify we actually transitioned to gameplay

--- a/e2e/gameplay.spec.ts
+++ b/e2e/gameplay.spec.ts
@@ -137,23 +137,20 @@ test.describe("Gameplay Flow - Menu to Game Transition", () => {
 		const nextBtn = page.locator("button.dialogue-next");
 		await expect(nextBtn).toBeVisible({ timeout: 10000 });
 
-		// Click NEXT >> until we reach BEGIN MISSION (with delays for stability)
+		// Click NEXT >> until we reach BEGIN MISSION (with force: true to bypass scroll issues)
 		let buttonText = await nextBtn.innerText();
 		let clickCount = 0;
 		while (buttonText.includes("NEXT") && clickCount < 20) {
-			await nextBtn.click();
-			await page.waitForTimeout(500);
+			await nextBtn.click({ force: true });
+			await page.waitForTimeout(300);
 			buttonText = await nextBtn.innerText();
 			clickCount++;
 		}
 
-		// Final click on BEGIN MISSION - use JS click to bypass animation issues
+		// Final click on BEGIN MISSION - use force click to bypass animation/scroll issues
 		const beginMissionBtn = page.locator('button.dialogue-next:has-text("BEGIN MISSION")');
 		await expect(beginMissionBtn).toBeVisible({ timeout: 5000 });
-		await page.evaluate(() => {
-			const btn = document.querySelector("button.dialogue-next") as HTMLButtonElement;
-			if (btn) btn.click();
-		});
+		await beginMissionBtn.click({ force: true });
 
 		// Wait for transition to start
 		await page.waitForTimeout(500);
@@ -514,8 +511,8 @@ test.describe("HUD and Player Interface", () => {
 			let buttonText = await nextBtn.innerText();
 			let clickCount = 0;
 			while (buttonText.includes("NEXT") && clickCount < 20) {
-				await nextBtn.click();
-				await page.waitForTimeout(500);
+				await nextBtn.click({ force: true });
+				await page.waitForTimeout(300);
 				buttonText = await nextBtn.innerText();
 				clickCount++;
 			}
@@ -523,10 +520,7 @@ test.describe("HUD and Player Interface", () => {
 			// Final click on BEGIN MISSION - use force:true for animation stability
 			const beginMissionBtn = page.locator('button.dialogue-next:has-text("BEGIN MISSION")');
 			await expect(beginMissionBtn).toBeVisible({ timeout: 5000 });
-			await page.evaluate(() => {
-				const btn = document.querySelector("button.dialogue-next") as HTMLButtonElement;
-				if (btn) btn.click();
-			});
+			await beginMissionBtn.click({ force: true });
 			await page.waitForTimeout(500);
 
 			// Verify we transitioned to gameplay
@@ -578,8 +572,8 @@ test.describe("Game World and Environment", () => {
 			let buttonText = await nextBtn.innerText();
 			let clickCount = 0;
 			while (buttonText.includes("NEXT") && clickCount < 20) {
-				await nextBtn.click();
-				await page.waitForTimeout(500);
+				await nextBtn.click({ force: true });
+				await page.waitForTimeout(300);
 				buttonText = await nextBtn.innerText();
 				clickCount++;
 			}
@@ -587,10 +581,7 @@ test.describe("Game World and Environment", () => {
 			// Final click on BEGIN MISSION - use force:true for animation stability
 			const beginMissionBtn = page.locator('button.dialogue-next:has-text("BEGIN MISSION")');
 			await expect(beginMissionBtn).toBeVisible({ timeout: 5000 });
-			await page.evaluate(() => {
-				const btn = document.querySelector("button.dialogue-next") as HTMLButtonElement;
-				if (btn) btn.click();
-			});
+			await beginMissionBtn.click({ force: true });
 			await page.waitForTimeout(500);
 
 			// Verify we transitioned to gameplay

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -167,7 +167,7 @@ export const skipCutscene = async (page: Page) => {
 	let buttonText = await nextBtn.innerText();
 	while (buttonText.includes("NEXT")) {
 		const previousText = buttonText;
-		await nextBtn.click();
+		await nextBtn.click({ force: true }); // force: true bypasses scroll issues
 		// Wait for the button text to change or for the button to disappear
 		await page.waitForFunction(
 			(args) => {
@@ -178,7 +178,7 @@ export const skipCutscene = async (page: Page) => {
 		);
 		buttonText = (await nextBtn.innerText()) || "";
 	}
-	await nextBtn.click(); // Final click on BEGIN MISSION
+	await nextBtn.click({ force: true }); // Final click on BEGIN MISSION
 	await waitForStable(page, 2000); // Give time for game world to initialize
 };
 

--- a/e2e/visual-audit.spec.ts
+++ b/e2e/visual-audit.spec.ts
@@ -46,11 +46,11 @@ test.describe("Visual Audit - Screenshot Generation", () => {
 		});
 		console.log("Captured Cutscene Start");
 
-		// Click through dialogue - use proper waiting
+		// Click through dialogue - use proper waiting with force: true
 		const nextBtn = page.locator("button.dialogue-next");
 		try {
 			await nextBtn.waitFor({ state: "visible", timeout: 10000 });
-			await nextBtn.click();
+			await nextBtn.click({ force: true });
 			await waitForStable(page, 500);
 			await page.screenshot({
 				path: path.join(SCREENSHOT_DIR, "04-cutscene-line-2.png"),
@@ -61,18 +61,15 @@ test.describe("Visual Audit - Screenshot Generation", () => {
 			let buttonText = await nextBtn.innerText();
 			let clickCount = 0;
 			while (buttonText.includes("NEXT") && clickCount < 20) {
-				await nextBtn.click();
-				await page.waitForTimeout(500);
+				await nextBtn.click({ force: true });
+				await page.waitForTimeout(300);
 				buttonText = await nextBtn.innerText();
 				clickCount++;
 			}
-			// Use JS click to bypass animation instability
+			// Final click with force: true
 			const beginMissionBtn = page.locator('button.dialogue-next:has-text("BEGIN MISSION")');
 			await expect(beginMissionBtn).toBeVisible({ timeout: 5000 });
-			await page.evaluate(() => {
-				const btn = document.querySelector("button.dialogue-next") as HTMLButtonElement;
-				if (btn) btn.click();
-			});
+			await beginMissionBtn.click({ force: true });
 			await page.waitForTimeout(500);
 			console.log("Passed through Cutscene");
 		} catch {

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,26 +2,43 @@
 
 ## Current State (2025-12-28)
 
-PR #33 (comprehensive E2E tests) has merged to main. The project is now in a **clean extraction phase** where conflicting branches are being replaced with cleanly rebased PRs.
+### Key Architectural Change: Level.tsx → GameWorld.tsx
 
-### Merge Queue Status
+**PR #33** (merged Dec 28) was a major refactor:
+- Deleted `src/Scenes/Level.tsx` (510 lines)
+- Added modular `src/Scenes/GameWorld.tsx` architecture:
+  - `GameWorld.tsx` (116 lines) - main scene
+  - `GameWorld/components/ChunkRenderer.tsx` (216 lines)
+  - `GameWorld/components/GameLogic.tsx` (199 lines)
 
-| Position | PR | Title | Status |
-|----------|-----|-------|--------|
-| 1 | #53 | Canteen modal redesign | 🔄 Ready for review |
-| 2 | #54 | Input lifecycle fix | 🔄 Ready for review |
-| 3 | #47 | Chunk persistence | ⏳ Needs rebase |
-| 4 | #48 | Character rescue | ⏳ Needs rebase |
-| 5 | #49 | Enemy health bars | ⏳ Needs rebase |
-| 6 | #46 | Base building | ⏳ Needs rebase |
-| 7 | #45 | Tactical features | ⏳ Later |
+**Impact**: All WIP PRs created before PR #33 that reference Level.tsx are now stale.
 
-### Stacked PRs
-- #55 stacked on #53 (Copilot additions)
-- #56 stacked on #54 (Copilot additions)
+### Merged Today
+- ✅ #54 - InputSystem lifecycle fix
+- ✅ #53 - Canteen modal redesign  
+- ✅ #57 - Memory bank update
+- ✅ #59 - Remove package-lock.json (pnpm project)
+
+### Closed as Stale/Superseded
+- ❌ #58 - Superseded by #53
+- ❌ #55, #56 - Stacked PRs, base merged
+- ❌ #48 - References deleted Level.tsx, needs full rewrite
+- ❌ #34 - Superseded by #33
+
+### Merged Today
+- ✅ #45 - Tactical simulation (type errors fixed, merged with admin override)
+
+### Remaining WIP PRs (Status)
+| PR | Title | Status |
+|----|-------|--------|
+| #47 | Chunk persistence | ⚠️ E2E tests failing (same as main branch) |
+| #49 | Enemy health bars | ⏳ Needs rebase onto latest main |
+| #46 | Base building UI | ⏳ Needs rebase onto latest main |
+| #41 | Test coverage 75% | ⚠️ Level.tsx tests need removal |
 
 ### Agent Coordination
-All PRs have been commented with merge order and rebase instructions. Agents (@cursor, @copilot, @claude) are coordinating via PR comments.
+- All PRs commented with architecture assessment notes
+- Main branch E2E tests are failing (15 tests) - needs investigation
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes E2E test flakiness in cutscene dialogue button clicks
- Uses `{ force: true }` on all cutscene dialogue button clicks to bypass scroll timeout issues
- Reduced wait time between clicks from 500ms to 300ms for faster tests

## Problem
E2E tests were failing with "scrolling into view if needed" timeouts on the cutscene dialogue button. This happened because:
1. The cutscene has a 3D canvas rendering behind the dialogue box
2. CI scroll behavior can be slow/problematic
3. The button is already visible but scroll actionability check times out

## Solution
Use Playwright's `{ force: true }` option which skips actionability checks. This is safe because we explicitly verify button visibility before clicking.

## Test Plan
- [x] Lint passes
- [ ] CI E2E tests should pass with these changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves E2E test robustness and speed for cutscene flows.
> 
> - Replace standard/JS clicks with `locator.click({ force: true })` for cutscene `NEXT >>` and `BEGIN MISSION` across `e2e/game.spec.ts`, `e2e/gameplay.spec.ts`, `e2e/visual-audit.spec.ts`, and `helpers.skipCutscene`
> - Reduce inter-click waits from 500ms to 300ms for faster execution
> - Update `memory-bank/activeContext.md` with current architecture and PR status
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5a4ac31a9ae97c639816cc0da40bc29a912d2c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->