### PR TITLE
fix: Resolve lint errors in E2E tests and App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,15 @@
  */
 
 import { useEffect, useRef } from "react";
+import type { useGameStore as GameStoreType } from "./stores/gameStore";
+
+// Extend Window for E2E testing
+declare global {
+	interface Window {
+		__gameStore?: typeof GameStoreType;
+	}
+}
+
 import { audioEngine } from "./Core/AudioEngine";
 import { inputSystem } from "./Core/InputSystem";
 import { Canteen } from "./Scenes/Canteen";
@@ -23,7 +32,7 @@ export function App() {
 	useEffect(() => {
 		// Expose store to window for E2E testing
 		if (typeof window !== "undefined") {
-			(window as any).__gameStore = useGameStore;
+			window.__gameStore = useGameStore;
 		}
 
 		// Load save data

--- a/src/Scenes/MainMenu.tsx
+++ b/src/Scenes/MainMenu.tsx
@@ -140,6 +140,7 @@ export function MainMenu() {
 						if (isLocked) ariaLabel += ". Locked - Difficulty can only be increased.";
 
 						return (
+							// biome-ignore lint/a11y/useSemanticElements: Custom styled radio group using buttons
 							<button
 								type="button"
 								role="radio"


### PR DESCRIPTION
## Summary
- Add proper Window interface type for __gameStore in E2E tests
- Replace (window as any) with typed window access
- Add biome-ignore for styled radio button group in MainMenu
- Fix import organization in App.tsx

All 777 tests pass, build succeeds, lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures E2E tests and app access the game store via a typed `window.__gameStore` and cleans up lint issues.
> 
> - **Types & Window exposure:** Declare `window.__gameStore` types in `e2e/chunk-persistence.spec.ts` and `src/App.tsx`; assign `useGameStore` to `window.__gameStore` without `any` casts
> - **E2E updates:** Replace `(window as any)` with `window.__gameStore`; tighten entity typing in `chunk-persistence.spec.ts`
> - **UI lint:** Add `// biome-ignore` to allow button-based custom radio group in `MainMenu`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a70c99f70e95c4ebdbad754dc252fae5ea8d8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->