### PR TITLE
fix: standardize Node.js 22 and pnpm 10 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: 20
-  PNPM_VERSION: 9
+  NODE_VERSION: 22
+  PNPM_VERSION: 10
 
 jobs:
   # Build job - runs lint, typecheck, and build, then uploads artifacts


### PR DESCRIPTION
Fixes the version mismatch in CI caused by an automated sync commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns CI environment versions across the workflow.
> 
> - Updates `env` in `.github/workflows/ci.yml` to `NODE_VERSION` `22` and `PNPM_VERSION` `10`, affecting both build and e2e jobs that consume these vars
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0387c3f6ceb4df0aa378a6cffdbcf9e4078e4f79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->