### PR TITLE
fix: move rank emblem rendering to overlay canvas for WebGL visibility

### DIFF
--- a/src/canvas/rankEmblems.ts
+++ b/src/canvas/rankEmblems.ts
@@ -91,7 +91,7 @@ const BADGE_OFFSET_Y = -2;
  * Call this after drawing the base sprite frame.
  */
 export function drawRankEmblem(
-	ctx: CanvasRenderingContext2D,
+	ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 	entityType: string,
 	spriteW: number,
 ): void {
@@ -248,7 +248,7 @@ export function drawRankEmblem(
 }
 
 function drawStar(
-	ctx: CanvasRenderingContext2D,
+	ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 	cx: number,
 	cy: number,
 	outerR: number,
@@ -273,7 +273,7 @@ function drawStar(
  * Drawn BEFORE the sprite to appear as a background glow.
  */
 export function drawFactionOutline(
-	ctx: CanvasRenderingContext2D,
+	ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 	entityType: string,
 	spriteW: number,
 	spriteH: number,

--- a/src/engine/runtime/tacticalRuntime.ts
+++ b/src/engine/runtime/tacticalRuntime.ts
@@ -1687,17 +1687,8 @@ export async function createTacticalRuntime(
 				);
 			}
 
-			// Rank emblem using the full emblem system from rankEmblems.ts
-			// This draws faction badges + unit-type symbols (chevron, star, etc.)
-			if (!isBuilding && !isResource && entityType && hasEmblem(entityType)) {
-				const screenPos = ljs.worldToScreen(ljs.vec2(tile.x, tile.y));
-				const spriteScreenW = ljs.cameraScale * 0.6;
-				const ctx = ljs.mainContext;
-				ctx.save();
-				ctx.translate(screenPos.x - spriteScreenW / 2, screenPos.y - spriteScreenW);
-				drawRankEmblem(ctx, entityType, spriteScreenW);
-				ctx.restore();
-			}
+			// Rank emblems drawn in gameRenderPost (overlay canvas, on top of WebGL)
+			// — see the "Rank emblems" section in gameRenderPost below.
 		}
 
 		// ── Build placement ghost ──
@@ -1960,6 +1951,38 @@ export async function createTacticalRuntime(
 		ctx.strokeStyle = "#f8fafc";
 		ctx.lineWidth = 1.5;
 		ctx.strokeRect(viewportRectX, viewportRectY, viewportRectW, viewportRectH);
+
+		// ── Rank emblems (overlay canvas — drawn ON TOP of WebGL) ──
+		// Rank emblems use Canvas2D path drawing (arc, lineTo, etc.) so they must
+		// render on the overlay canvas (drawContext), NOT mainContext which sits
+		// behind the WebGL layer and would be invisible.
+		for (const eid of options.world.runtime.alive) {
+			const isBuilding = Flags.isBuilding[eid] === 1;
+			const isResource = Flags.isResource[eid] === 1;
+			if (isBuilding || isResource) continue;
+
+			const entityType = options.world.runtime.entityTypeIndex.get(eid);
+			if (!entityType || !hasEmblem(entityType)) continue;
+
+			// Fog culling: skip entities in unexplored tiles (unless player)
+			if (fogGrid && fogGridWidth > 0 && Faction.id[eid] !== 1) {
+				const tileX = Math.floor(Position.x[eid] / TILE_SIZE);
+				const tileY = Math.floor(Position.y[eid] / TILE_SIZE);
+				if (tileX >= 0 && tileY >= 0 && tileX < fogGridWidth && tileY < fogGridHeight) {
+					if (fogGrid[tileY * fogGridWidth + tileX] < 2) continue;
+				}
+			}
+
+			const px = Position.x[eid];
+			const py = Position.y[eid];
+			const tile = pixelToTile(px, py);
+			const screenPos = ljs.worldToScreen(ljs.vec2(tile.x, tile.y));
+			const spriteScreenW = ljs.cameraScale * 0.6;
+			ctx.save();
+			ctx.translate(screenPos.x - spriteScreenW / 2, screenPos.y - spriteScreenW);
+			drawRankEmblem(ctx, entityType, spriteScreenW);
+			ctx.restore();
+		}
 
 		// ── Selection box overlay ──
 		if (selectionBoxScreen) {


### PR DESCRIPTION
## Summary
- Move rank emblem drawing from `gameRender` (uses `ljs.mainContext` / Canvas2D behind WebGL) to `gameRenderPost` (uses `ljs.drawContext` / overlay canvas on top of WebGL)
- Add fog-of-war culling to the moved emblem rendering so enemy emblems in unexplored tiles stay hidden
- Widen `drawRankEmblem`, `drawStar`, and `drawFactionOutline` context param types to accept `OffscreenCanvasRenderingContext2D` for LittleJS `drawContext` compatibility

## Context
LittleJS renders with three canvas layers: `mainCanvas` (Canvas2D, background), `glCanvas` (WebGL, middle), and an overlay canvas (`drawContext`, foreground). The rank emblems were drawing on `mainContext` which sits **behind** the WebGL layer, making them invisible in real browsers with WebGL enabled. They only appeared in headless/test environments where LittleJS falls back to Canvas2D mode.

Building and resource rendering already uses `drawTile()` (WebGL pipeline) and sprite rendering uses `drawTile()` via the atlas adapter -- those were not affected. The terrain chunk rendering on `mainContext` is intentional and shows through transparent WebGL areas.

## Test plan
- [x] `pnpm build` passes (TypeScript + Vite)
- [x] `pnpm test` passes (114 files, 2057 tests)
- [x] `biome check` clean on modified files
- [ ] Verify on deployed site: rank emblems (chevrons, stars, etc.) visible on unit sprites
- [ ] Verify buildings render as PNG images (not just labels)
- [ ] Verify unit sprites render as animated animals (not grey squares)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Visual Improvements**
  * Rank emblems now render as a dedicated overlay, improving visual clarity and display order.
  * Rank emblems respect fog of war and no longer appear for unexplored enemy unit positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->