### PR TITLE
fix: WebGL sprite rendering, POC sidebar layout, full system wiring

### DIFF
--- a/src/engine/rendering/atlasAdapter.ts
+++ b/src/engine/rendering/atlasAdapter.ts
@@ -117,6 +117,11 @@ const ENTITY_ANIMAL_MAP: Record<string, { animal: AnimalName; defaultAnim: strin
 	siphon_drone: { animal: "cobra", defaultAnim: "Idle" },
 	serpent_king: { animal: "cobra", defaultAnim: "Idle" },
 	kommandant_ironjaw: { animal: "crocodile", defaultAnim: "Idle" },
+	// Scale-Guard bosses
+	captain_scalebreak: { animal: "crocodile", defaultAnim: "Idle" },
+	warden_fangrot: { animal: "crocodile", defaultAnim: "Idle" },
+	venom: { animal: "cobra", defaultAnim: "Idle" },
+	broodmother: { animal: "crocodile", defaultAnim: "Idle" },
 	// Neutrals
 	bandit_boar: { animal: "boar", defaultAnim: "Idle" },
 	wild_fox: { animal: "fox", defaultAnim: "Idle" },

--- a/src/engine/runtime/RuntimeHost.tsx
+++ b/src/engine/runtime/RuntimeHost.tsx
@@ -1,8 +1,15 @@
-import { createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { SkirmishAI } from "@/ai/skirmishAI";
 import { createSkirmishGameAdapter } from "@/ai/skirmishGameAdapter";
 import type { SkirmishSessionConfig } from "@/features/skirmish/types";
+import { AlertBanner } from "@/solid/hud/AlertBanner";
+import { BossHealthBar } from "@/solid/hud/BossHealthBar";
+import { CommandTransmission } from "@/solid/hud/CommandTransmission";
+import { ObjectivesPanel } from "@/solid/hud/ObjectivesPanel";
+import { ResourceBar } from "@/solid/hud/ResourceBar";
 import { TacticalHUD } from "@/solid/hud/TacticalHUD";
+import { TutorialOverlay } from "@/solid/hud/TutorialOverlay";
+import { PauseOverlay } from "@/solid/screens/PauseOverlay";
 import { createGameBridge } from "../bridge/gameBridge";
 import { createSolidBridge } from "../bridge/solidBridge";
 import {
@@ -177,10 +184,16 @@ export function RuntimeHost(props: RuntimeHostProps) {
 
 		void (async () => {
 			try {
+				// Find the minimap canvas from the sidebar (rendered by TacticalHUD)
+				const minimapCanvas = document.querySelector<HTMLCanvasElement>(
+					'[data-testid="minimap-canvas"]',
+				);
+
 				const runtime = await createTacticalRuntime({
 					container,
 					world,
 					bridge,
+					minimapCanvas: minimapCanvas ?? undefined,
 					onTick: () => {
 						// Drain and process UI commands before systems run
 						const commands = bridge.drainCommands();
@@ -299,14 +312,79 @@ export function RuntimeHost(props: RuntimeHostProps) {
 		});
 	});
 
+	// Autosave every 3 minutes during active gameplay
+	onMount(() => {
+		const AUTOSAVE_INTERVAL_MS = 3 * 60 * 1000;
+		const autoSaveInterval = window.setInterval(() => {
+			const world = worldInstance;
+			if (!world || world.session.phase !== "playing") return;
+			solidBridge.emit.saveGame();
+		}, AUTOSAVE_INTERVAL_MS);
+
+		onCleanup(() => {
+			window.clearInterval(autoSaveInterval);
+		});
+	});
+
+	// Pause state: derived from bridge screen signal
+	const isPaused = createMemo(() => solidBridge.accessors.screen() === "paused");
+
+	// Minimal AppState adapter for PauseOverlay (only uses screen/setScreen)
+	const pauseAppAdapter: { screen: () => string; setScreen: (s: string) => void } = {
+		screen: () => (isPaused() ? "paused" : "game"),
+		setScreen: (s: string) => {
+			if (s === "game") solidBridge.emit.resume();
+			else if (s === "main-menu") {
+				solidBridge.emit.resume();
+				props.onPhaseChange?.("defeat");
+			}
+		},
+	};
+
 	return (
-		<div class="relative h-full w-full overflow-hidden bg-jungle-950">
-			<div ref={containerEl} class="absolute inset-0" data-testid="runtime-host-container" />
+		<div class="flex h-full w-full flex-col-reverse overflow-hidden bg-black text-sm text-slate-200 md:flex-row">
+			{/* Sidebar: Bottom on mobile, Left on desktop — matches POC layout */}
 			<TacticalHUD
 				bridge={solidBridge.accessors}
 				emit={solidBridge.emit}
 				missionId={props.missionId}
 			/>
+
+			{/* Main Game Area */}
+			<div class="relative flex-1 cursor-crosshair overflow-hidden bg-black">
+				<div ref={containerEl} class="absolute inset-0" data-testid="runtime-host-container" />
+
+				{/* Top Resource Bar — inside game area, overlays canvas */}
+				<ResourceBar bridge={solidBridge.accessors} />
+
+				{/* Objectives overlay — right side */}
+				<div class="pointer-events-auto absolute right-2 top-14 z-20 hidden w-64 sm:right-4 sm:block sm:w-72">
+					<ObjectivesPanel bridge={solidBridge.accessors} />
+				</div>
+
+				{/* Alert Banner — top-right */}
+				<div class="pointer-events-auto absolute right-2 top-2 z-20 w-72 sm:right-4">
+					<AlertBanner bridge={solidBridge.accessors} emit={solidBridge.emit} />
+				</div>
+
+				{/* Boss Health Bar — top-center */}
+				<BossHealthBar bridge={solidBridge.accessors} />
+
+				{/* Command Transmission — bottom-center overlay */}
+				<div class="pointer-events-auto absolute inset-x-0 bottom-4 z-20 flex justify-center px-4">
+					<CommandTransmission bridge={solidBridge.accessors} />
+				</div>
+
+				{/* Tutorial overlay */}
+				{props.missionId && <TutorialOverlay missionId={props.missionId} />}
+			</div>
+
+			<Show when={isPaused()}>
+				<PauseOverlay
+					app={pauseAppAdapter as unknown as Parameters<typeof PauseOverlay>[0]["app"]}
+					emit={solidBridge.emit}
+				/>
+			</Show>
 		</div>
 	);
 }

--- a/src/engine/runtime/tacticalRuntime.ts
+++ b/src/engine/runtime/tacticalRuntime.ts
@@ -71,6 +71,8 @@ export interface TacticalRuntimeOptions {
 	world: GameWorld;
 	bridge: GameBridge;
 	onTick?: (world: GameWorld) => void;
+	/** External minimap canvas in the sidebar HUD. If provided, minimap renders here instead of the overlay canvas. */
+	minimapCanvas?: HTMLCanvasElement;
 }
 
 /** Terrain type → LittleJS Color (r, g, b, a scaled 0-1).
@@ -170,6 +172,18 @@ export async function createTacticalRuntime(
 	let fogGridWidth = 0;
 	let fogGridHeight = 0;
 	let terrainChunks: TerrainChunk[] = [];
+
+	// Terrain chunk WebGL textures — each chunk canvas becomes a TextureInfo+TileInfo
+	// for rendering on the WebGL layer (same as entities) instead of Canvas2D mainContext.
+	// This ensures sprites drawn via drawTile are visible above terrain.
+	const terrainChunkGLInfos: Array<{
+		tileInfo: InstanceType<typeof ljs.TileInfo>;
+		centerX: number;
+		centerY: number;
+		sizeX: number;
+		sizeY: number;
+	}> = [];
+	let terrainChunksConverted = false;
 
 	// Building tile infos — keyed by building type (e.g. "barracks", "watchtower")
 	// Uses LittleJS TileInfo so buildings render on the WebGL layer (same as units/shapes).
@@ -765,6 +779,16 @@ export async function createTacticalRuntime(
 	// ═══════════════════════════════════════════════════════
 
 	function getMinimapLayout(): { x: number; y: number; width: number; height: number } {
+		// When using external minimap canvas (sidebar HUD), draw at origin of that canvas
+		if (options.minimapCanvas) {
+			return {
+				x: 0,
+				y: 0,
+				width: options.minimapCanvas.width,
+				height: options.minimapCanvas.height,
+			};
+		}
+		// Fallback: draw on overlay canvas at bottom-right
 		const sw = ljs.mainCanvasSize.x;
 		const sh = ljs.mainCanvasSize.y;
 		const minimapWidth = Math.min(200, Math.max(160, Math.round(sw * 0.26)));
@@ -778,6 +802,9 @@ export async function createTacticalRuntime(
 	}
 
 	function screenPointInMinimap(screenX: number, screenY: number): boolean {
+		// With external minimap canvas, clicks on the sidebar minimap are handled
+		// by the DOM event listener on the canvas element, not by checking overlay coords.
+		if (options.minimapCanvas) return false;
 		const m = getMinimapLayout();
 		return (
 			screenX >= m.x && screenX <= m.x + m.width && screenY >= m.y && screenY <= m.y + m.height
@@ -793,6 +820,17 @@ export async function createTacticalRuntime(
 			x: Math.max(0, Math.min(worldSize.width, localX * worldSize.width)),
 			y: Math.max(0, Math.min(worldSize.height, localY * worldSize.height)),
 		};
+	}
+
+	/** Convert a click on the external minimap canvas to world coordinates and recenter. */
+	function handleExternalMinimapClick(canvasX: number, canvasY: number): void {
+		const worldSize = getWorldPixelSize();
+		const w = options.minimapCanvas?.width ?? 200;
+		const h = options.minimapCanvas?.height ?? 200;
+		const worldX = (canvasX / w) * worldSize.width;
+		const worldY = (canvasY / h) * worldSize.height;
+		const tile = pixelToTile(worldX, worldY);
+		ljs.setCameraPos(ljs.vec2(tile.x, tile.y));
 	}
 
 	// ═══════════════════════════════════════════════════════
@@ -887,6 +925,18 @@ export async function createTacticalRuntime(
 				);
 			};
 			img.src = `${tileBase}${relPath}`;
+		}
+
+		// Wire external minimap click handler
+		if (options.minimapCanvas) {
+			options.minimapCanvas.addEventListener("pointerdown", (e: PointerEvent) => {
+				const rect = options.minimapCanvas!.getBoundingClientRect();
+				const scaleX = options.minimapCanvas!.width / rect.width;
+				const scaleY = options.minimapCanvas!.height / rect.height;
+				const canvasX = (e.clientX - rect.left) * scaleX;
+				const canvasY = (e.clientY - rect.top) * scaleY;
+				handleExternalMinimapClick(canvasX, canvasY);
+			});
 		}
 
 		// Initialize audio (real Tone.js engine + SFX bridge + music controller)
@@ -1251,7 +1301,7 @@ export async function createTacticalRuntime(
 			}
 		}
 
-		// Escape — cancel build mode, cancel current mode, or deselect all
+		// Escape — cancel build mode, cancel current mode, deselect, or pause
 		if (ljs.keyWasPressed("Escape")) {
 			if (buildPlacementMode) {
 				buildPlacementMode = false;
@@ -1260,9 +1310,18 @@ export async function createTacticalRuntime(
 				pushAlert("Build cancelled", "info");
 			} else if (inputMode !== "normal") {
 				inputMode = "normal";
-			} else {
+			} else if (getSelectedEntityIds().length > 0) {
 				clearSelectionState();
+			} else {
+				// Nothing to cancel — pause the game
+				options.world.session.phase = "paused";
+				ljs.setPaused(true);
 			}
+		}
+
+		// Unpause when session phase returns to playing (e.g. from PauseOverlay resume)
+		if (ljs.paused && options.world.session.phase === "playing") {
+			ljs.setPaused(false);
 		}
 
 		// Space — center camera on last alert position
@@ -1316,46 +1375,40 @@ export async function createTacticalRuntime(
 	}
 
 	function gameRender(): void {
-		// ── Terrain (pre-rendered tile chunks from tilePainter) ──
-		if (terrainChunks.length > 0) {
-			const ctx = ljs.mainContext;
-			const scale = ljs.cameraScale;
-			const camPos = ljs.cameraPos;
-			const canvasW = ljs.mainCanvas.width;
-			const canvasH = ljs.mainCanvas.height;
-			// LittleJS camera: center of screen = cameraPos in world units
-			// LittleJS worldToScreen: screenX = (wx - cx) * scale + W/2
-			//                         screenY = (wy - cy) * -scale + H/2  (Y-up)
-			// Canvas2D drawImage uses Y-down, so we flip the image vertically.
-			const camPixelX = camPos.x * TILE_SIZE;
-			const camPixelY = camPos.y * TILE_SIZE;
-			const screenScale = scale / TILE_SIZE;
+		// ── Terrain (pre-rendered tile chunks via WebGL) ──
+		// Convert chunk canvases to WebGL textures once, then draw via drawTile
+		// so terrain and entity sprites are on the same WebGL layer.
+		if (terrainChunks.length > 0 && !terrainChunksConverted) {
+			terrainChunksConverted = true;
 			for (const chunk of terrainChunks) {
-				// Chunk is in pixel coords (chunk.x, chunk.y) with Y-down convention.
-				// Apply LittleJS Y-flip: negate Y component.
-				const screenX = (chunk.x - camPixelX) * screenScale + canvasW / 2;
-				const screenYGameTop = -(chunk.y - camPixelY) * screenScale + canvasH / 2;
-				const screenW = chunk.width * screenScale;
-				const screenH = chunk.height * screenScale;
-				// In LittleJS screen space, the chunk spans from
-				// screenYGameTop - screenH (screen top) to screenYGameTop (screen bottom)
-				const screenTop = screenYGameTop - screenH;
-				// Frustum cull
-				if (
-					screenX + screenW < 0 ||
-					screenTop + screenH < 0 ||
-					screenX > canvasW ||
-					screenTop > canvasH
-				)
-					continue;
-				// Draw chunk flipped vertically to match LittleJS Y-up convention
-				ctx.save();
-				ctx.translate(screenX, screenYGameTop);
-				ctx.scale(1, -1);
-				ctx.drawImage(chunk.canvas, 0, 0, screenW, screenH);
-				ctx.restore();
+				// Transfer chunk canvas to OffscreenCanvas for WebGL texture creation
+				// (TextureInfo accepts HTMLImageElement|OffscreenCanvas, not HTMLCanvasElement)
+				const offscreen = new OffscreenCanvas(chunk.canvas.width, chunk.canvas.height);
+				const offCtx = offscreen.getContext("2d");
+				if (offCtx) offCtx.drawImage(chunk.canvas, 0, 0);
+				const texInfo = new ljs.TextureInfo(offscreen);
+				const ti = new ljs.TileInfo(ljs.vec2(0, 0), ljs.vec2(chunk.width, chunk.height), texInfo);
+				terrainChunkGLInfos.push({
+					tileInfo: ti,
+					centerX: (chunk.x + chunk.width / 2) / TILE_SIZE,
+					centerY: (chunk.y + chunk.height / 2) / TILE_SIZE,
+					sizeX: chunk.width / TILE_SIZE,
+					sizeY: chunk.height / TILE_SIZE,
+				});
 			}
-		} else {
+		}
+
+		if (terrainChunkGLInfos.length > 0) {
+			for (const info of terrainChunkGLInfos) {
+				// Draw with negative sizeY to flip vertically (chunk canvas is Y-down,
+				// LittleJS world is Y-up). This makes terrain match entity positions.
+				ljs.drawTile(
+					ljs.vec2(info.centerX, info.centerY),
+					ljs.vec2(info.sizeX, -info.sizeY),
+					info.tileInfo,
+				);
+			}
+		} else if (terrainChunks.length === 0) {
 			// Fallback: flat color terrain while tiles load
 			const terrainGrid = options.world.runtime.terrainGrid;
 			if (terrainGrid) {
@@ -1595,20 +1648,27 @@ export async function createTacticalRuntime(
 					// Determine animation based on entity state
 					const orderQueue = options.world.runtime.orderQueues.get(eid);
 					const currentOrder = orderQueue?.[0]?.type;
-					const isMoving = currentOrder === "move";
-					const animName = isMoving ? "Run" : currentOrder === "attack" ? "Spin" : "Idle";
+					// Detect actual movement: any order with a target the unit is walking to
+					const hasTarget =
+						orderQueue?.[0]?.targetX !== undefined && orderQueue?.[0]?.targetY !== undefined;
+					const distToTarget = hasTarget
+						? Math.abs(orderQueue![0].targetX! - px) + Math.abs(orderQueue![0].targetY! - py)
+						: 0;
+					const isActuallyMoving = hasTarget && distToTarget > TILE_SIZE;
+					const isAttacking = currentOrder === "attack" && distToTarget < TILE_SIZE * 2;
+
+					const animName = isAttacking ? "Spin" : isActuallyMoving ? "Run" : "Idle";
 
 					const tileInfo = getEntityTileInfo(entityType, animName, worldElapsed);
+
 					if (tileInfo) {
 						const drawSize = getEntityDrawSize(entityType);
 						let size = drawSize ? ljs.vec2(drawSize.x, drawSize.y) : ljs.vec2(1.2, 1.2);
 
 						// Flip sprite horizontally when moving left
-						// Check target position vs current position for direction
-						if (isMoving && orderQueue?.[0]) {
+						if (isActuallyMoving && orderQueue?.[0]) {
 							const targetX = orderQueue[0].targetX;
 							if (targetX !== undefined && targetX < px) {
-								// Moving left: flip by making width negative
 								size = ljs.vec2(-Math.abs(size.x), size.y);
 							}
 						}
@@ -1827,10 +1887,18 @@ export async function createTacticalRuntime(
 	}
 
 	function gameRenderPost(): void {
-		// ── CRT-styled Minimap (drawn in screen space via overlayCanvas) ──
-		const ctx = ljs.drawContext;
-		if (!ctx) return;
+		// ── CRT-styled Minimap ──
+		// Renders to external sidebar canvas if available, else falls back to overlay canvas
+		const minimapCtx = options.minimapCanvas
+			? options.minimapCanvas.getContext("2d")
+			: ljs.drawContext;
+		if (!minimapCtx) return;
+		// Clear external minimap canvas each frame
+		if (options.minimapCanvas) {
+			minimapCtx.clearRect(0, 0, options.minimapCanvas.width, options.minimapCanvas.height);
+		}
 
+		const ctx = minimapCtx;
 		const minimap = getMinimapLayout();
 		const worldSize = getWorldPixelSize();
 
@@ -1956,6 +2024,9 @@ export async function createTacticalRuntime(
 		// Rank emblems use Canvas2D path drawing (arc, lineTo, etc.) so they must
 		// render on the overlay canvas (drawContext), NOT mainContext which sits
 		// behind the WebGL layer and would be invisible.
+		// Note: use ljs.drawContext here, NOT `ctx` which may be the external minimap canvas.
+		const emblemCtx = ljs.drawContext;
+		if (!emblemCtx) return;
 		for (const eid of options.world.runtime.alive) {
 			const isBuilding = Flags.isBuilding[eid] === 1;
 			const isResource = Flags.isResource[eid] === 1;
@@ -1978,10 +2049,10 @@ export async function createTacticalRuntime(
 			const tile = pixelToTile(px, py);
 			const screenPos = ljs.worldToScreen(ljs.vec2(tile.x, tile.y));
 			const spriteScreenW = ljs.cameraScale * 0.6;
-			ctx.save();
-			ctx.translate(screenPos.x - spriteScreenW / 2, screenPos.y - spriteScreenW);
-			drawRankEmblem(ctx, entityType, spriteScreenW);
-			ctx.restore();
+			emblemCtx.save();
+			emblemCtx.translate(screenPos.x - spriteScreenW / 2, screenPos.y - spriteScreenW);
+			drawRankEmblem(emblemCtx, entityType, spriteScreenW);
+			emblemCtx.restore();
 		}
 
 		// ── Selection box overlay ──
@@ -1990,11 +2061,11 @@ export async function createTacticalRuntime(
 			const minY = Math.min(selectionBoxScreen.startY, selectionBoxScreen.endY);
 			const boxWidth = Math.abs(selectionBoxScreen.endX - selectionBoxScreen.startX);
 			const boxHeight = Math.abs(selectionBoxScreen.endY - selectionBoxScreen.startY);
-			ctx.fillStyle = "rgba(34, 197, 94, 0.15)";
-			ctx.fillRect(minX, minY, boxWidth, boxHeight);
-			ctx.strokeStyle = "rgba(134, 239, 172, 0.95)";
-			ctx.lineWidth = 1;
-			ctx.strokeRect(minX, minY, boxWidth, boxHeight);
+			emblemCtx.fillStyle = "rgba(34, 197, 94, 0.15)";
+			emblemCtx.fillRect(minX, minY, boxWidth, boxHeight);
+			emblemCtx.strokeStyle = "rgba(134, 239, 172, 0.95)";
+			emblemCtx.lineWidth = 1;
+			emblemCtx.strokeRect(minX, minY, boxWidth, boxHeight);
 		}
 	}
 

--- a/src/engine/systems/waveSpawnerSystem.ts
+++ b/src/engine/systems/waveSpawnerSystem.ts
@@ -1,24 +1,146 @@
 /**
- * Wave Spawner System — Spawns enemy waves at timed intervals.
+ * Wave Spawner System -- Spawns enemy waves at timed intervals.
  *
  * Reads waveCounter from world.runtime and spawns enemy entities
  * based on the current scenario phase. Wave spawning is triggered
  * by scenario actions (setWaveCounter, incrementWaveCounter) and
  * this system handles the actual entity spawning.
  *
+ * Composition scales with wave count:
+ *   Early (1-3):  skinks + a few gators
+ *   Mid   (4-6):  gators + vipers + scout_lizards
+ *   Late  (7+):   croc_champions + siphon_drones + snappers
+ *
+ * Stats are pulled from the entity registry (getUnit()) — no
+ * hardcoded HP/damage values.
+ *
  * Pure function on GameWorld.
  */
 
 import { TILE_SIZE } from "@/config/constants";
-import { Attack, Speed, VisionRadius } from "@/engine/world/components";
+import { resolveCategoryId } from "@/engine/content/ids";
+import { createRng, deriveGameplaySeed, type Rng } from "@/engine/random/seed";
+import { Armor, Attack, Speed, VisionRadius } from "@/engine/world/components";
 import type { GameWorld } from "@/engine/world/gameWorld";
 import { spawnUnit } from "@/engine/world/gameWorld";
+import { getUnit } from "@/entities/registry";
+import type { UnitDef } from "@/entities/types";
+
+// ---------------------------------------------------------------------------
+// Wave composition tables
+// ---------------------------------------------------------------------------
+
+/** A weighted entry in the wave composition pool. */
+interface WaveSlot {
+	unitType: string;
+	/** Relative weight for PRNG selection. */
+	weight: number;
+}
+
+/** Early waves (1-3): cannon-fodder skinks backed by a few gators. */
+const EARLY_POOL: readonly WaveSlot[] = [
+	{ unitType: "skink", weight: 5 },
+	{ unitType: "gator", weight: 2 },
+];
+
+/** Mid waves (4-6): infantry core with ranged and scout support. */
+const MID_POOL: readonly WaveSlot[] = [
+	{ unitType: "gator", weight: 4 },
+	{ unitType: "viper", weight: 3 },
+	{ unitType: "scout_lizard", weight: 2 },
+	{ unitType: "skink", weight: 1 },
+];
+
+/** Late waves (7+): elite heavies, support drainers, and turrets. */
+const LATE_POOL: readonly WaveSlot[] = [
+	{ unitType: "croc_champion", weight: 3 },
+	{ unitType: "siphon_drone", weight: 2 },
+	{ unitType: "snapper", weight: 2 },
+	{ unitType: "gator", weight: 2 },
+	{ unitType: "viper", weight: 1 },
+];
+
+function getPoolForWave(waveCounter: number): readonly WaveSlot[] {
+	if (waveCounter <= 3) return EARLY_POOL;
+	if (waveCounter <= 6) return MID_POOL;
+	return LATE_POOL;
+}
+
+// ---------------------------------------------------------------------------
+// Weighted random pick
+// ---------------------------------------------------------------------------
+
+function pickWeighted(pool: readonly WaveSlot[], rng: Rng): string {
+	let totalWeight = 0;
+	for (const slot of pool) {
+		totalWeight += slot.weight;
+	}
+	let roll = rng.next() * totalWeight;
+	for (const slot of pool) {
+		roll -= slot.weight;
+		if (roll <= 0) return slot.unitType;
+	}
+	// Fallback to last entry (shouldn't happen with valid weights).
+	return pool[pool.length - 1].unitType;
+}
+
+// ---------------------------------------------------------------------------
+// Per-session wave RNG (lazy, seeded from gameplaySeeds.waves)
+// ---------------------------------------------------------------------------
+
+let waveRng: Rng | null = null;
+let waveRngSeed = -1;
+
+function getWaveRng(world: GameWorld): Rng {
+	const seed = world.rng.gameplaySeeds.waves ?? world.rng.numericSeed;
+	if (waveRng === null || waveRngSeed !== seed) {
+		waveRngSeed = seed;
+		waveRng = createRng(deriveGameplaySeed(seed, `waves-${world.time.tick}`));
+	}
+	return waveRng;
+}
+
+// ---------------------------------------------------------------------------
+// Wave timers
+// ---------------------------------------------------------------------------
 
 /** Accumulated wave spawn timer per wave counter value. */
 const waveTimers = new Map<number, number>();
 
 /** Minimum interval between wave spawns in seconds. */
 const WAVE_COOLDOWN = 30;
+
+// ---------------------------------------------------------------------------
+// Spawn helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn a single enemy unit from its registry definition.
+ *
+ * Reads HP, armor, damage, range, speed, and vision from the UnitDef
+ * so stats stay in sync with the entity data files.
+ */
+function spawnWaveUnit(world: GameWorld, def: UnitDef, x: number, y: number): number {
+	const eid = spawnUnit(world, {
+		x,
+		y,
+		faction: def.faction,
+		unitType: def.id,
+		categoryId: resolveCategoryId(def.category),
+		health: { current: def.hp, max: def.hp },
+	});
+	Armor.value[eid] = def.armor;
+	Attack.damage[eid] = def.damage;
+	Attack.range[eid] = def.range * TILE_SIZE;
+	Attack.cooldown[eid] = def.attackCooldown;
+	Speed.value[eid] = def.speed * TILE_SIZE;
+	VisionRadius.value[eid] = def.visionRadius * TILE_SIZE;
+	return eid;
+}
+
+// ---------------------------------------------------------------------------
+// Main tick
+// ---------------------------------------------------------------------------
 
 /**
  * Run one tick of the wave spawner system.
@@ -41,30 +163,31 @@ export function runWaveSpawnerSystem(world: GameWorld): void {
 	// Reset timer so we don't spawn again for this wave value
 	waveTimers.set(waveCounter, -999999);
 
+	const rng = getWaveRng(world);
+	const pool = getPoolForWave(waveCounter);
+
 	// Find enemy spawn zones
 	for (const [zoneId, rect] of world.runtime.zoneRects) {
 		if (!zoneId.includes("enemy") && !zoneId.includes("spawn") && !zoneId.includes("scale")) {
 			continue;
 		}
 
-		// Spawn wave units at zone center
-		const centerX = rect.x + rect.width / 2;
-		const centerY = rect.y + rect.height / 2;
+		// Wave size scales with wave counter, capped at 8
 		const count = Math.min(2 + waveCounter, 8);
 
 		for (let i = 0; i < count; i++) {
-			const eid = spawnUnit(world, {
-				x: centerX + (i % 4) * 20 - 30,
-				y: centerY + Math.floor(i / 4) * 20 - 10,
-				faction: "scale_guard",
-				unitType: "gator",
-				health: { current: 10, max: 10 },
-			});
-			Attack.damage[eid] = 2;
-			Attack.range[eid] = 1 * TILE_SIZE;
-			Attack.cooldown[eid] = 1.5;
-			Speed.value[eid] = 5 * TILE_SIZE;
-			VisionRadius.value[eid] = 5 * TILE_SIZE;
+			const unitType = pickWeighted(pool, rng);
+			const def = getUnit(unitType);
+			if (!def) {
+				console.warn(`[waveSpawner] Unknown unit type '${unitType}', skipping`);
+				continue;
+			}
+
+			// Scatter units within the zone rect using RNG
+			const x = rect.x + rng.nextInt(Math.max(1, Math.floor(rect.width)));
+			const y = rect.y + rng.nextInt(Math.max(1, Math.floor(rect.height)));
+
+			spawnWaveUnit(world, def, x, y);
 		}
 
 		world.events.push({
@@ -82,4 +205,6 @@ export function runWaveSpawnerSystem(world: GameWorld): void {
 /** Reset wave timers (for new missions/tests). */
 export function resetWaveTimers(): void {
 	waveTimers.clear();
+	waveRng = null;
+	waveRngSeed = -1;
 }

--- a/src/solid/hud/ResourceBar.tsx
+++ b/src/solid/hud/ResourceBar.tsx
@@ -1,59 +1,50 @@
 /**
- * ResourceBar -- Top HUD bar showing Fish, Timber, Salvage, and Population.
+ * ResourceBar — Top resource bar inside the game viewport.
  *
- * SolidJS component reading from solidBridge stores for fine-grained
- * reactive updates. Military digital-counter styling with monospace font.
- * Wrapped in PanelFrame for corner bracket decorations + canvas-grain texture.
+ * Matches POC layout: full-width bar at top of game area with
+ * Fish, Timber, Salvage, Population, and status display.
  */
 
 import type { Component } from "solid-js";
 import type { SolidBridgeAccessors } from "@/engine/bridge/solidBridge";
-import { PanelFrame } from "./PanelFrame";
-
-function ResourceItem(props: { label: string; value: number }) {
-	return (
-		<div class="flex items-center gap-2 rounded-md border border-slate-600/70 bg-slate-900/18 px-2.5 py-1.5 sm:px-3 sm:py-2">
-			<span class="text-[10px] uppercase tracking-[0.24em] text-slate-400">{props.label}</span>
-			<span class="min-w-[3ch] text-right font-mono text-sm tabular-nums tracking-[0.18em] text-slate-100">
-				{props.value}
-			</span>
-		</div>
-	);
-}
 
 export const ResourceBar: Component<{ bridge: SolidBridgeAccessors }> = (props) => {
 	return (
-		<PanelFrame>
-			<div
-				role="status"
-				aria-label="Field Economy"
-				data-testid="resource-bar"
-				class="canvas-grain border border-green-500/20 bg-slate-950/86 shadow-[0_0_0_1px_rgba(0,255,65,0.06),0_18px_40px_rgba(0,0,0,0.34)]"
-			>
-				<div class="flex flex-wrap items-center gap-2 p-2.5 sm:gap-4 sm:p-3">
-					<div class="flex items-center gap-2 pr-1 sm:pr-2">
-						<span class="rounded border border-green-500/25 bg-green-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.22em] text-green-400">
-							TACTICAL NET
-						</span>
-						<span class="hidden font-mono text-[10px] uppercase tracking-[0.22em] text-slate-400 sm:inline">
-							FIELD ECONOMY
-						</span>
-					</div>
-					<div class="flex flex-1 flex-wrap items-center gap-2 sm:gap-3">
-						<ResourceItem label="Fish" value={props.bridge.resources.fish} />
-						<ResourceItem label="Timber" value={props.bridge.resources.timber} />
-						<ResourceItem label="Salvage" value={props.bridge.resources.salvage} />
-					</div>
-					<div class="flex w-full items-center justify-between gap-2 rounded-md border border-slate-600/70 bg-slate-900/18 px-3 py-2 sm:ml-auto sm:w-auto sm:justify-start">
-						<span class="rounded border border-green-500/25 bg-green-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.22em] text-green-400">
-							POP
-						</span>
-						<span class="font-mono text-sm tracking-[0.18em] text-slate-100">
-							{props.bridge.population.current}/{props.bridge.population.max}
-						</span>
-					</div>
+		<div
+			role="status"
+			aria-label="Field Economy"
+			data-testid="resource-bar"
+			class="ui-panel pointer-events-auto absolute left-0 top-0 z-20 flex h-10 w-full items-center justify-between border-b-2 bg-opacity-95 px-2 text-xs md:h-12 md:border-b-4 md:px-6 md:text-sm"
+		>
+			<div class="flex space-x-3 md:space-x-6">
+				<div class="flex items-center space-x-1 md:space-x-2">
+					<div class="h-3 w-3 rounded-full border border-sky-300 bg-sky-500 shadow-sm md:h-4 md:w-4" />
+					<span class="hidden md:inline">Fish: </span>
+					<span class="font-bold text-sky-200">{props.bridge.resources.fish}</span>
+				</div>
+				<div class="flex items-center space-x-1 md:space-x-2">
+					<div class="h-3 w-3 border border-amber-500 bg-amber-700 shadow-sm md:h-4 md:w-4" />
+					<span class="hidden md:inline">Timber: </span>
+					<span class="font-bold text-amber-600">{props.bridge.resources.timber}</span>
+				</div>
+				<div class="flex items-center space-x-1 md:space-x-2">
+					<div class="h-3 w-3 rounded-sm border border-slate-400 bg-slate-300 shadow-sm md:h-4 md:w-4" />
+					<span class="hidden md:inline">Salvage: </span>
+					<span class="font-bold text-slate-200">{props.bridge.resources.salvage}</span>
+				</div>
+				<div class="flex items-center space-x-1 md:space-x-2">
+					<div class="h-3 w-3 rounded-sm border border-red-400 bg-red-600 shadow-sm md:h-4 md:w-4" />
+					<span class="hidden md:inline">Pop: </span>
+					<span class="font-bold text-red-400">
+						{props.bridge.population.current}/{props.bridge.population.max}
+					</span>
 				</div>
 			</div>
-		</PanelFrame>
+			<div class="flex items-center space-x-3 md:space-x-6">
+				<div class="hidden font-bold uppercase tracking-widest text-green-400 sm:block">
+					TACTICAL NET
+				</div>
+			</div>
+		</div>
 	);
 };

--- a/src/solid/hud/SelectionPanel.tsx
+++ b/src/solid/hud/SelectionPanel.tsx
@@ -12,8 +12,9 @@
 
 import { type Component, createMemo, For, Show } from "solid-js";
 import type { SolidBridgeAccessors, SolidBridgeEmit } from "@/engine/bridge/solidBridge";
+import { ALL_RESEARCH_ENTITIES } from "@/entities/research";
+import type { ResearchDef } from "@/entities/types";
 import { SimpleTooltip } from "./MilitaryTooltip";
-import { PanelFrame } from "./PanelFrame";
 
 interface ActionDef {
 	id: string;
@@ -160,6 +161,27 @@ function getTrainOptionsForBuilding(primaryLabel: string): TrainOption[] {
 	return [];
 }
 
+/** Check if selected building can research. */
+function isResearchBuilding(primaryLabel: string): boolean {
+	const lower = primaryLabel.toLowerCase();
+	return lower.includes("armory") || lower.includes("research den");
+}
+
+/** Get all available research options with formatted cost strings. */
+function getResearchOptions(): Array<{ def: ResearchDef; costStr: string }> {
+	const options: Array<{ def: ResearchDef; costStr: string }> = [];
+	for (const def of Object.values(ALL_RESEARCH_ENTITIES)) {
+		const parts: string[] = [];
+		if ((def.cost.fish ?? 0) > 0) parts.push(`F${def.cost.fish}`);
+		if ((def.cost.timber ?? 0) > 0) parts.push(`T${def.cost.timber}`);
+		if ((def.cost.salvage ?? 0) > 0) parts.push(`S${def.cost.salvage}`);
+		options.push({ def, costStr: parts.join(" ") || "Free" });
+	}
+	return options;
+}
+
+const RESEARCH_OPTIONS = getResearchOptions();
+
 const ACTION_STYLE =
 	"flex items-center justify-between rounded-none border border-slate-600/70 bg-slate-900/85 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-100 hover:border-green-500/50 hover:bg-slate-800/85 transition-colors";
 
@@ -192,79 +214,114 @@ export const SelectionPanel: Component<{
 		return getTrainOptionsForBuilding(sel.primaryLabel);
 	});
 
+	const showResearch = createMemo(() => {
+		const sel = selection();
+		if (!sel) return false;
+		return selectionType() === "building" && isResearchBuilding(sel.primaryLabel);
+	});
+
 	return (
 		<Show when={selection()}>
 			{(sel) => (
-				<PanelFrame>
-					<div
-						data-testid="selection-panel"
-						class="canvas-grain border border-slate-600/70 bg-slate-950/88 shadow-[0_18px_40px_rgba(0,0,0,0.34)]"
-					>
-						<div class="flex flex-col gap-2 p-3">
-							{/* Header */}
-							<div class="flex items-center justify-between gap-2 border-b border-slate-600/60 pb-2">
-								<span class="font-mono text-xs uppercase tracking-[0.18em] text-slate-100">
-									{sel().primaryLabel}
-								</span>
-								<span class="rounded border border-green-500/25 bg-green-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.22em] text-green-400">
-									{sel().entityIds.length} UNIT{sel().entityIds.length !== 1 ? "S" : ""}
-								</span>
-							</div>
+				<div data-testid="selection-panel" class="flex flex-col gap-1 md:gap-2">
+					{/* Header — matches POC selection info */}
+					<h2 class="text-base font-bold leading-tight text-sky-300 md:text-xl">
+						{sel().primaryLabel}
+					</h2>
+					<div class="text-[10px] uppercase tracking-wider text-slate-400 md:text-xs">
+						{sel().entityIds.length} unit{sel().entityIds.length !== 1 ? "s" : ""} selected
+					</div>
 
-							{/* Action buttons for workers and military */}
-							<Show when={actions().length > 0}>
-								<div class="grid grid-cols-2 gap-2">
-									<For each={actions()}>
-										{(action) => (
-											<SimpleTooltip label={`${action.label} [${action.hotkey}]`} side="top">
+					{/* Action buttons for workers and military */}
+					<Show when={actions().length > 0}>
+						<div class="grid grid-cols-2 gap-2">
+							<For each={actions()}>
+								{(action) => (
+									<SimpleTooltip label={`${action.label} [${action.hotkey}]`} side="top">
+										<button
+											type="button"
+											class={ACTION_STYLE}
+											onClick={() => action.handler(props.emit)}
+										>
+											{action.label}
+											<span class="text-[9px] tracking-[0.2em] text-slate-500">
+												{action.hotkey}
+											</span>
+										</button>
+									</SimpleTooltip>
+								)}
+							</For>
+						</div>
+					</Show>
+
+					{/* Training options for buildings */}
+					<Show when={trainOptions().length > 0}>
+						<div class="border-t border-slate-600/60 pt-2">
+							<span class="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-400">
+								Train Units
+							</span>
+							<div class="mt-2 grid grid-cols-2 gap-2">
+								<For each={trainOptions()}>
+									{(opt) => {
+										const affordable = () => {
+											// Basic affordability check
+											return props.bridge.resources.fish >= 0;
+										};
+										return (
+											<button
+												type="button"
+												class={affordable() ? ACTION_STYLE : DISABLED_STYLE}
+												disabled={!affordable()}
+												onClick={() => props.emit.queueUnit(opt.unitId)}
+											>
+												{opt.name}
+												<span class="text-[9px] tracking-[0.2em] text-slate-500">T</span>
+											</button>
+										);
+									}}
+								</For>
+							</div>
+						</div>
+					</Show>
+
+					{/* Research options for armory */}
+					<Show when={showResearch()}>
+						<div class="border-t border-slate-600/60 pt-2">
+							<span class="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-400">
+								Research
+							</span>
+							<div class="mt-2 grid grid-cols-2 gap-2">
+								<For each={RESEARCH_OPTIONS}>
+									{(opt) => {
+										const canAfford = () => {
+											const r = props.bridge.resources;
+											return (
+												r.fish >= (opt.def.cost.fish ?? 0) &&
+												r.timber >= (opt.def.cost.timber ?? 0) &&
+												r.salvage >= (opt.def.cost.salvage ?? 0)
+											);
+										};
+										return (
+											<SimpleTooltip label={opt.def.description} side="top">
 												<button
 													type="button"
-													class={ACTION_STYLE}
-													onClick={() => action.handler(props.emit)}
+													class={canAfford() ? ACTION_STYLE : DISABLED_STYLE}
+													disabled={!canAfford()}
+													onClick={() => props.emit.issueResearch(opt.def.id)}
 												>
-													{action.label}
-													<span class="text-[9px] tracking-[0.2em] text-slate-500">
-														{action.hotkey}
+													<span class="truncate">{opt.def.name}</span>
+													<span class="text-[8px] tracking-[0.1em] text-slate-500">
+														{opt.costStr}
 													</span>
 												</button>
 											</SimpleTooltip>
-										)}
-									</For>
-								</div>
-							</Show>
-
-							{/* Training options for buildings */}
-							<Show when={trainOptions().length > 0}>
-								<div class="border-t border-slate-600/60 pt-2">
-									<span class="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-400">
-										Train Units
-									</span>
-									<div class="mt-2 grid grid-cols-2 gap-2">
-										<For each={trainOptions()}>
-											{(opt) => {
-												const affordable = () => {
-													// Basic affordability check
-													return props.bridge.resources.fish >= 0;
-												};
-												return (
-													<button
-														type="button"
-														class={affordable() ? ACTION_STYLE : DISABLED_STYLE}
-														disabled={!affordable()}
-														onClick={() => props.emit.queueUnit(opt.unitId)}
-													>
-														{opt.name}
-														<span class="text-[9px] tracking-[0.2em] text-slate-500">T</span>
-													</button>
-												);
-											}}
-										</For>
-									</div>
-								</div>
-							</Show>
+										);
+									}}
+								</For>
+							</div>
 						</div>
-					</div>
-				</PanelFrame>
+					</Show>
+				</div>
 			)}
 		</Show>
 	);

--- a/src/solid/hud/TacticalHUD.tsx
+++ b/src/solid/hud/TacticalHUD.tsx
@@ -1,81 +1,87 @@
 /**
- * TacticalHUD -- Composes all HUD components into a single overlay layout.
+ * TacticalHUD — POC-faithful sidebar layout.
  *
- * Positions components absolutely over the tactical canvas:
- * - ResourceBar at top (with PanelFrame + canvas-grain)
- * - SelectionPanel + BuildMenu at bottom-left (with PanelFrame)
- * - AlertBanner at top-right
- * - ObjectivesPanel at right
- * - BossHealthBar at top-center (when boss present)
- * - CommandTransmission at bottom-center (when dialogue active)
- * - ErrorFeedback at top-right (below alerts)
- * - TutorialOverlay at bottom-center (missions 1-4)
+ * Desktop: Left sidebar (w-64) with Minimap | Selection Info | Action Panel
+ * Mobile: Bottom bar (h-48) with 3 columns
+ *
+ * Matches the original poc_final.html layout:
+ *   body flex-col-reverse md:flex-row
+ *   sidebar: w-full md:w-64 h-48 md:h-full
+ *     - Minimap (w-1/3 md:w-full md:h-64)
+ *     - Selection Info (w-1/3 md:w-full flex-1)
+ *     - Action Panel (w-1/3 md:w-full md:h-64)
  */
 
-import type { Component } from "solid-js";
+import { type Component, createMemo, Show } from "solid-js";
 import type { SolidBridgeAccessors, SolidBridgeEmit } from "@/engine/bridge/solidBridge";
-import { AlertBanner } from "./AlertBanner";
-import { BossHealthBar } from "./BossHealthBar";
 import { BuildMenu } from "./BuildMenu";
-import { CommandTransmission } from "./CommandTransmission";
 import { ErrorFeedback } from "./ErrorFeedback";
 import { createErrorFeedback } from "./errorState";
-import { ObjectivesPanel } from "./ObjectivesPanel";
-import { ResourceBar } from "./ResourceBar";
 import { SelectionPanel } from "./SelectionPanel";
-import { TutorialOverlay } from "./TutorialOverlay";
 
 export const TacticalHUD: Component<{
 	bridge: SolidBridgeAccessors;
 	emit: SolidBridgeEmit;
-	/** Current mission ID for tutorial prompts */
 	missionId?: string;
 }> = (props) => {
-	const { errors, pushError: _pushError } = createErrorFeedback();
+	const { errors } = createErrorFeedback();
+
+	const selection = () => props.bridge.selection();
+	const hasSelection = createMemo(() => {
+		const sel = selection();
+		return sel && sel.entityIds.length > 0;
+	});
 
 	return (
 		<div
 			data-testid="tactical-hud"
-			class="pointer-events-none absolute inset-0 z-20 overflow-hidden"
+			class="ui-panel z-20 flex h-48 w-full flex-shrink-0 flex-row border-t-4 border-slate-600 shadow-2xl md:h-full md:w-64 md:flex-col md:border-r-4 md:border-t-0"
 		>
-			{/* Top bar -- ResourceBar */}
-			<div class="pointer-events-auto absolute inset-x-0 top-0 z-10 px-2 pt-2 sm:px-4 sm:pt-3">
-				<ResourceBar bridge={props.bridge} />
+			{/* ── Minimap ── */}
+			<div class="flex w-1/3 items-center justify-center border-r-2 border-slate-700 bg-black p-1 md:h-64 md:w-full md:border-b-4 md:border-r-0 md:p-2">
+				<div class="relative h-full w-full max-h-[200px] max-w-[200px] cursor-crosshair border-2 border-slate-600">
+					{/* Minimap canvas — rendered by tacticalRuntime into this element */}
+					<canvas
+						data-testid="minimap-canvas"
+						width="200"
+						height="200"
+						class="block h-full w-full"
+						style={{ "image-rendering": "pixelated" }}
+					/>
+				</div>
 			</div>
 
-			{/* Top-center -- BossHealthBar (when boss present) */}
-			<div class="absolute left-1/2 top-14 z-30 flex -translate-x-1/2 justify-center md:top-16">
-				<BossHealthBar bridge={props.bridge} />
+			{/* ── Selection Info ── */}
+			<div class="flex w-1/3 flex-1 flex-col gap-1 overflow-y-auto border-r-2 border-slate-700 bg-slate-900 p-2 md:w-full md:gap-2 md:border-b-4 md:border-r-0 md:p-4">
+				<Show
+					when={hasSelection()}
+					fallback={
+						<h2 class="text-base font-bold leading-tight text-sky-300 md:text-xl">No Selection</h2>
+					}
+				>
+					<SelectionPanel bridge={props.bridge} emit={props.emit} />
+				</Show>
 			</div>
 
-			{/* Top-right -- AlertBanner (always visible, higher z-index) */}
-			<div class="pointer-events-auto absolute left-1/2 top-16 z-20 w-80 -translate-x-1/2 sm:left-auto sm:right-4 sm:top-20 sm:translate-x-0">
-				<AlertBanner bridge={props.bridge} emit={props.emit} />
-			</div>
-
-			{/* Right -- ObjectivesPanel (hidden on mobile < 640px to avoid overlap) */}
-			<div class="pointer-events-auto absolute right-2 top-52 z-10 hidden w-64 sm:right-4 sm:top-56 sm:block sm:w-72">
-				<ObjectivesPanel bridge={props.bridge} />
-			</div>
-
-			{/* Top-right -- ErrorFeedback (below alerts) */}
-			<div class="absolute right-2 top-36 z-30 sm:right-4">
-				<ErrorFeedback errors={errors} />
-			</div>
-
-			{/* Bottom-left -- SelectionPanel + BuildMenu */}
-			<div class="pointer-events-auto absolute bottom-2 left-2 z-10 flex flex-col gap-2 sm:bottom-4 sm:left-4">
-				<SelectionPanel bridge={props.bridge} emit={props.emit} />
+			{/* ── Action Panel ── */}
+			<div class="grid h-full w-1/3 content-start gap-1 overflow-y-auto bg-slate-800 p-1 sm:grid-cols-2 md:h-64 md:w-full md:gap-2 md:p-3">
 				<BuildMenu bridge={props.bridge} emit={props.emit} />
 			</div>
 
-			{/* Bottom-center -- CommandTransmission (when dialogue active) */}
-			<div class="pointer-events-auto absolute inset-x-0 bottom-4 z-20 flex justify-center px-4">
-				<CommandTransmission bridge={props.bridge} />
+			{/* Error feedback (absolute, floats above sidebar) */}
+			<div class="absolute right-2 top-2 z-30 md:left-2 md:right-auto md:top-auto md:bottom-2">
+				<ErrorFeedback errors={errors} />
 			</div>
 
-			{/* Bottom-center -- TutorialOverlay (missions 1-4, below transmission) */}
-			{props.missionId && <TutorialOverlay missionId={props.missionId} />}
+			{/* POC-style panel CSS */}
+			<style>{`
+				.ui-panel {
+					background-color: #1e293b;
+					color: #e2e8f0;
+					font-family: 'Courier New', Courier, monospace;
+					text-shadow: 1px 1px 0 #000;
+				}
+			`}</style>
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

- **Sprite rendering fixed** — terrain moved from Canvas2D to WebGL so entity sprites, buildings, and shapes are no longer hidden behind opaque terrain layer
- **POC-faithful HUD layout** — left sidebar (desktop) / bottom bar (mobile) with minimap + selection info + action panel, matching `docs/archive/references/poc_final.html`
- **Minimap wired to sidebar** — renders on external canvas in the HUD sidebar with click-to-recenter camera
- **4 missing boss sprites** — captain_scalebreak, warden_fangrot, venom, broodmother added to atlas adapter
- **Pause menu connected** — Escape key triggers pause, PauseOverlay mounted with resume/save/quit
- **Research UI** — research options display in SelectionPanel when armory is selected
- **Wave spawner variety** — enemy waves scale from skinks (early) to croc_champions (late) using registry stats
- **Autosave** — 3-minute interval during active gameplay
- **Resource bar** — POC-style full-width top bar with Fish/Timber/Salvage/Pop

## Root cause (sprites)

LittleJS creates `glCanvas` (WebGL, first in DOM) then `mainCanvas` (Canvas2D, second = visually on top). Terrain was drawn on Canvas2D `mainContext`, creating an opaque layer covering all WebGL `drawTile` calls. Fix: convert terrain chunks to `OffscreenCanvas` → `TextureInfo` → `TileInfo` and draw via `drawTile()` on the same WebGL layer.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 2057/2057 tests pass
- [x] `pnpm lint` — clean
- [x] Chrome DevTools MCP visual verification: otter sprites visible, building PNGs render, terrain tiles correct, sidebar layout matches POC
- [ ] Verify on deployed GH Pages after merge
- [ ] Test Escape → pause → resume flow
- [ ] Test research queue from armory
- [ ] Mobile responsive layout (bottom bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four new Scale-Guard boss entity types.
  * Research options for armory/research den buildings.
  * Minimap click-to-recenter camera.

* **Improvements**
  * Redesigned HUD into a responsive sidebar + main game area; revamped Resource Bar and Selection Panel layouts.
  * Wave spawning now produces varied, progression-weighted compositions.
  * Pause/resume controls and periodic autosave (every 3 minutes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->